### PR TITLE
Update to .NET 9

### DIFF
--- a/FluxTune/FluxTune.csproj
+++ b/FluxTune/FluxTune.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
As of now, the latest version of .NET is .NET 9, and .NET 8 will reach its end of life on November 10, 2026. Upgrading to .NET 9 should be relatively seamless and does not require any complex actions.